### PR TITLE
Dynamically sets tooltip width for edges

### DIFF
--- a/src/js/azdata/view/azDataGraph.js
+++ b/src/js/azdata/view/azDataGraph.js
@@ -103,13 +103,14 @@ azdataGraph.prototype.insertWeightedInvertedEdge = function (parent, id, value, 
  * cell - <mxCell> that specifies the cell the retrieved tooltip is for.
  */
 azdataGraph.prototype.getStyledTooltipForCell = function (cell) {
-    const tooltipWidth = cell.edge ? 'width: 25em;' : 'width: 45em;';
+    const tooltipWidth = cell.edge ? 'width: auto;' : 'width: 45em;';
     const justifyContent = 'display: flex; justify-content: space-between;';
     const boldText = 'font-weight: bold;';
     const tooltipLineHeight = 'padding-top: .13em; line-height: .5em;';
     const centerText = 'text-align: center;';
     const headerBottomMargin = 'margin-bottom: 1.5em;';
     const footerTopMargin = 'margin-top: 1.5em;';
+    const metricLabelMargin = 'margin-right: 4em;';
 
     if (cell.value != null && cell.value.metrics != null) {
         var tooltip = `<div style=\"${tooltipWidth}\">`;
@@ -126,7 +127,7 @@ azdataGraph.prototype.getStyledTooltipForCell = function (cell) {
             tooltip += `<div style=\"${tooltipLineHeight}\">`;
 
             tooltip += `<div style=\"${justifyContent}\">`;
-            tooltip += `<span style=\"${boldText}\">${cell.value.metrics[i].name}</span>`;
+            tooltip += `<span style=\"${boldText} ${metricLabelMargin}\">${cell.value.metrics[i].name}</span>`;
             tooltip += `<span>${cell.value.metrics[i].value}</span>`;
             tooltip += '</div>';
 


### PR DESCRIPTION
This PR dynamically sets the width for tooltip edges so that longer metric labels don't overflow onto the next line.