### PR TITLE
Adding a fix for images not loading when using vscode-file urls

### DIFF
--- a/src/js/util/mxUrlConverter.js
+++ b/src/js/util/mxUrlConverter.js
@@ -121,7 +121,8 @@ mxUrlConverter.prototype.isRelativeUrl = function(url)
 {
 	return url != null && url.substring(0, 2) != '//' && url.substring(0, 7) != 'http://' &&
 		url.substring(0, 8) != 'https://' && url.substring(0, 10) != 'data:image' &&
-		url.substring(0, 7) != 'file://';
+		url.substring(0, 7) != 'file://' 
+		&& url.substring(0,14) != 'vscode-file://'; // {{SQL CARBON EDIT}} Adding a rule for vscode file protocol. 
 };
 
 /**

--- a/src/js/util/mxUrlConverter.js
+++ b/src/js/util/mxUrlConverter.js
@@ -121,8 +121,7 @@ mxUrlConverter.prototype.isRelativeUrl = function(url)
 {
 	return url != null && url.substring(0, 2) != '//' && url.substring(0, 7) != 'http://' &&
 		url.substring(0, 8) != 'https://' && url.substring(0, 10) != 'data:image' &&
-		url.substring(0, 7) != 'file://' 
-		&& url.substring(0,14) != 'vscode-file://'; // {{SQL CARBON EDIT}} Adding a rule for vscode file protocol. 
+		url.substring(0, 7) != 'file://' && url.substring(0,14) != 'vscode-file://'; // {{SQL CARBON EDIT}} Adding a rule for vscode-file// protocol. 
 };
 
 /**


### PR DESCRIPTION
Mx graph (azdataGraph) has a function that checks for relative Urls and if it is relative, it adds the path of `window.location.href`

Before the vscode-ads-merge (https://github.com/microsoft/azuredatastudio/pull/17979), we were using 'file://' protocol in our urls and it was working fine. 

However, after merge, when ads changed its prefix from 'file://' to 'vscode-file://' this check started failing and mxgraph started adding the window.location.href to our image urls thus failing image fetches.


