### PR TITLE
Change JS file import to require explicit flag

### DIFF
--- a/src/js/mxClient.js
+++ b/src/js/mxClient.js
@@ -649,7 +649,7 @@ if (mxClient.IS_VML)
 // PREPROCESSOR-REMOVE-START
 // If script is loaded via CommonJS, do not write <script> tags to the page
 // for dependencies. These are already included in the build.
-if (mxForceIncludes || !(typeof module === 'object' && module.exports != null))
+if (mxForceIncludes)
 {
 // PREPROCESSOR-REMOVE-END
 	mxClient.include(mxClient.basePath+'/js/util/mxLog.js');

--- a/test/queryplan/queryPlanColors.html
+++ b/test/queryplan/queryPlanColors.html
@@ -6,6 +6,7 @@
 <head>
 	<title>Query Plan Cell Color test</title>
 	<script type="text/javascript">
+		mxForceIncludes = true;
 		mxBasePath = '../../src';
 	</script>
 	<script type="text/javascript" src="./src/js/graph.js" ></script>

--- a/test/queryplan/queryPlanListener.html
+++ b/test/queryplan/queryPlanListener.html
@@ -6,6 +6,7 @@
 <head>
 	<title>Query Plan Listener test</title>
 	<script type="text/javascript">
+		mxForceIncludes = true;
 		mxBasePath = '../../src';
 	</script>
 	<script type="text/javascript" src="./src/js/graph.js"></script>

--- a/test/queryplan/queryPlanZoom.html
+++ b/test/queryplan/queryPlanZoom.html
@@ -6,6 +6,7 @@
 <head>
 	<title>Query Plan Zoom test</title>
 	<script type="text/javascript">
+		mxForceIncludes = true;
 		mxBasePath = '../../src';
 	</script>
 	<script type="text/javascript" src="./src/js/graph.js" ></script>

--- a/test/queryplan/queryplan.html
+++ b/test/queryplan/queryplan.html
@@ -6,6 +6,7 @@
 <head>
 	<title>Query Plan test</title>
 	<script type="text/javascript">
+		mxForceIncludes = true;
 		mxBasePath = '../../src';
 	</script>
 	<script type="text/javascript" src="./src/js/graph.js" ></script>


### PR DESCRIPTION
Loading the JS files is creating in webmode with uses CommonJS module but doesn't meet the condition tested in mxClient.  Only the tests use the unbundled JS files so they can set the include flag explicitly. 