### PR TITLE
Corrects up arrow key selection logic

### DIFF
--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -213,7 +213,8 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
 
             --edgeIndex;
             if (edgeIndex >= 1) {
-                this.graph.setSelectionCell(source.edges[edgeIndex]);
+                let edge = source.edges[edgeIndex];
+                this.graph.setSelectionCell(edge.target);
             }
         }
     };


### PR DESCRIPTION
This PR fixes selection logic, so that the vertex directly above the currently selected one is selected instead of the arrow to the left of the vertex.

Before "up" arrow key is pressed:
![image](https://user-images.githubusercontent.com/87730006/153969133-8e8752cf-c53f-4c1b-8585-a342ea612054.png)

After "up" arrow key is pressed:
![image](https://user-images.githubusercontent.com/87730006/153969187-c8730c20-bec8-4a76-81eb-9f4d816f0a2e.png)
