### PR TITLE
Fix Long Graph Cell Labels

### DIFF
--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -276,7 +276,22 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
 
     graph.convertValueToString = function (cell) {
         if (cell.value != null && cell.value.label != null) {
-            return cell.value.label;
+            let splitLabel = cell.value.label.split('\n');
+            let cellLabel = '';
+            for (let index = 0; index < splitLabel.length; ++index) {
+                if (splitLabel[index].length > 20) {
+                    cellLabel += splitLabel[index].substring(0, 17) + '...';
+                }
+                else {
+                    cellLabel += splitLabel[index];
+                }
+
+                if (index < splitLabel.length - 1) {
+                    cellLabel += '\n';
+                }
+            }
+
+            return cellLabel;
         }
 
         return azdataGraph.prototype.convertValueToString.apply(this, arguments); // "supercall"

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -276,7 +276,9 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
 
     graph.convertValueToString = function (cell) {
         if (cell.value != null && cell.value.label != null) {
-            let splitLabel = cell.value.label.split(/\n/);
+            debugger;
+            let hasWindowsEOL = cell.value.label.includes('\r\n');
+            let splitLabel = cell.value.label.split(/\r\n|\n/);
             let cellLabel = splitLabel.map((str, i) => {
                 let label = '';
                 if (str.length > 20) {
@@ -287,8 +289,14 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
                 }
 
                 return label;
-            })
-            .join(getEndOfLine());
+            });
+
+            if (hasWindowsEOL) {
+                cellLabel = cellLabel.join('\r\n');
+            }
+            else {
+                cellLabel = cellLabel.join('\n');
+            }
 
             return cellLabel;
         }
@@ -382,10 +390,6 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
     finally {
         graph.getModel().endUpdate();
     }
-};
-
-const getEndOfLine = function () {
-    return navigator.appVersion.indexOf('Win') === -1 ? '\n' : '\r\n';
 };
 
 /**

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -276,20 +276,20 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
 
     graph.convertValueToString = function (cell) {
         if (cell.value != null && cell.value.label != null) {
-            let splitLabel = cell.value.label.split('\n');
             let cellLabel = '';
-            for (let index = 0; index < splitLabel.length; ++index) {
-                if (splitLabel[index].length > 20) {
-                    cellLabel += splitLabel[index].substring(0, 17) + '...';
+            let splitLabel = cell.value.label.split('\n');
+            splitLabel.forEach((str, i) => {
+                if (str.length > 20) {
+                    cellLabel += str.substring(0, 17) + '...';
                 }
                 else {
-                    cellLabel += splitLabel[index];
+                    cellLabel += str;
                 }
 
-                if (index < splitLabel.length - 1) {
+                if (i < splitLabel.length - 1) {
                     cellLabel += '\n';
                 }
-            }
+            });
 
             return cellLabel;
         }

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -278,7 +278,7 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
         if (cell.value != null && cell.value.label != null) {
             let hasWindowsEOL = cell.value.label.includes('\r\n');
             let splitLabel = cell.value.label.split(/\r\n|\n/);
-            let cellLabel = splitLabel.map((str, i) => {
+            let cellLabel = splitLabel.map(str => {
                 let label = '';
                 if (str.length > 20) {
                     label += str.substring(0, 17) + '...';

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -276,7 +276,6 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
 
     graph.convertValueToString = function (cell) {
         if (cell.value != null && cell.value.label != null) {
-            debugger;
             let hasWindowsEOL = cell.value.label.includes('\r\n');
             let splitLabel = cell.value.label.split(/\r\n|\n/);
             let cellLabel = splitLabel.map((str, i) => {

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -277,8 +277,7 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
     graph.convertValueToString = function (cell) {
         if (cell.value != null && cell.value.label != null) {
             let splitLabel = cell.value.label.split(/\n/);
-
-            return splitLabel.map((str, i) => {
+            let cellLabel = splitLabel.map((str, i) => {
                 let label = '';
                 if (str.length > 20) {
                     label += str.substring(0, 17) + '...';
@@ -290,6 +289,8 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
                 return label;
             })
             .join(getEndOfLine());
+
+            return cellLabel;
         }
 
         return azdataGraph.prototype.convertValueToString.apply(this, arguments); // "supercall"

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -276,22 +276,20 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
 
     graph.convertValueToString = function (cell) {
         if (cell.value != null && cell.value.label != null) {
-            let cellLabel = '';
             let splitLabel = cell.value.label.split(/\n/);
-            splitLabel.forEach((str, i) => {
+
+            return splitLabel.map((str, i) => {
+                let label = '';
                 if (str.length > 20) {
-                    cellLabel += str.substring(0, 17) + '...';
+                    label += str.substring(0, 17) + '...';
                 }
                 else {
-                    cellLabel += str;
+                    label += str;
                 }
 
-                if (i < splitLabel.length - 1) {
-                    cellLabel += getEndOfLine();
-                }
-            });
-
-            return cellLabel;
+                return label;
+            })
+            .join(getEndOfLine());
         }
 
         return azdataGraph.prototype.convertValueToString.apply(this, arguments); // "supercall"

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -277,7 +277,7 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
     graph.convertValueToString = function (cell) {
         if (cell.value != null && cell.value.label != null) {
             let cellLabel = '';
-            let splitLabel = cell.value.label.split('\n');
+            let splitLabel = cell.value.label.split(/\n/);
             splitLabel.forEach((str, i) => {
                 if (str.length > 20) {
                     cellLabel += str.substring(0, 17) + '...';
@@ -287,7 +287,7 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
                 }
 
                 if (i < splitLabel.length - 1) {
-                    cellLabel += '\n';
+                    cellLabel += getEndOfLine();
                 }
             });
 
@@ -383,6 +383,10 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
     finally {
         graph.getModel().endUpdate();
     }
+};
+
+const getEndOfLine = function () {
+    return navigator.appVersion.indexOf('Win') === -1 ? '\n' : '\r\n';
 };
 
 /**


### PR DESCRIPTION
This PR fixes #18389

As can be seen in the screenshot, longer graph cell names are truncated to prevent them from extending into the regions of other cells.
![image](https://user-images.githubusercontent.com/87730006/154180871-26a9710b-e198-426a-b442-797558102873.png)
