### PR TITLE
Revert "Fix Long Graph Cell Labels (#44)"

### DIFF
--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -283,28 +283,7 @@ azdataQueryPlan.prototype.init = function (container, iconPaths) {
 
     graph.convertValueToString = function (cell) {
         if (cell.value != null && cell.value.label != null) {
-            let hasWindowsEOL = cell.value.label.includes('\r\n');
-            let splitLabel = cell.value.label.split(/\r\n|\n/);
-            let cellLabel = splitLabel.map(str => {
-                let label = '';
-                if (str.length > 20) {
-                    label += str.substring(0, 17) + '...';
-                }
-                else {
-                    label += str;
-                }
-
-                return label;
-            });
-
-            if (hasWindowsEOL) {
-                cellLabel = cellLabel.join('\r\n');
-            }
-            else {
-                cellLabel = cellLabel.join('\n');
-            }
-
-            return cellLabel;
+            return cell.value.label;
         }
 
         return azdataGraph.prototype.convertValueToString.apply(this, arguments); // "supercall"


### PR DESCRIPTION
This PR fixes the following issue in the ADS repo: https://github.com/microsoft/azuredatastudio/issues/18818

This reverts commit cba8fc2ff113ba398b78ef5a8452d3afde92a16c, which truncated long label names, so they wouldn't collide with neighboring node labels.

As seen here, long node labels are no longer colliding with neighboring node labels:
![image](https://user-images.githubusercontent.com/87730006/161343471-4116797c-a4de-44bd-ac99-177f168942f4.png)
