### PR TITLE
Using mxCells instead of nodes to draw polygon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azdataGraph",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azdataGraph",
   "description": "azdataGraph is a derivative of mxGraph, which is a fully client side JavaScript diagramming library that uses SVG and HTML for rendering.",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "homepage": "https://github.com/microsoft/azdataGraph",
   "author": "Microsoft",
   "license": "Apache-2.0",

--- a/test/queryplan/queryplanPolygon.html
+++ b/test/queryplan/queryplanPolygon.html
@@ -22,8 +22,8 @@
 			var badgePaths = getBadgePaths(imageBasePath);
 
 			var azdataGraph = new azdataQueryPlan(container, graph, iconPaths, badgePaths);
-
-			var points = azdataGraph.getPolygonPerimeter(azdataGraph.queryPlanGraph);
+			const cell = azdataGraph.graph.model.getCell('element-7')
+			var points = azdataGraph.getPolygonPerimeter(cell);
 			var samplePolygon = azdataGraph.drawPolygon(
                 points,
                 "rgba(236, 0, 140,0.1)",


### PR DESCRIPTION
The cordinates stored in nodes are only used for the initializing the first position of nodes in the graph. later on, these points are not updated.
Switching to mxCells to get the latest cordinates of the polygon. This will make the draw polygon function work with zoom
