### PR TITLE
Improved Node Labels

### DIFF
--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -580,7 +580,6 @@ azdataQueryPlan.prototype.adjustGraphNodeHorizontalPositions = function (node) {
                 if (distanceFromPreviousNode <= STANDARD_NODE_DISTANCE) {
                     let shiftToRightAmount = Math.max(size.width, IDEAL_LONG_LABEL_NODE_DISTANCE) - distanceFromPreviousNode;
                     currentNode.position.x += shiftToRightAmount;
-                    console.log(shiftToRightAmount);
 
                     this.shiftParentAndChildNodePositionsHorizontally(currentNode.parent, shiftToRightAmount);
                 }

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -321,13 +321,12 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
             let splitLabel = cell.value.label.split(/\r\n|\n/);
             let cellLabel = splitLabel.map((str, index) => {
                 let label = '';
-
                 if (index === 0 && !cell.value.icon?.includes('columnstore')) {
                     // This regex removes any text contained in parenthesis in the operation name
                     // i.e. "Clustered Index Seek (Clustered)" becomes "Clustered Index Seek"
                     label += str.replace(/\(([^)]+)\)/g, '');
                 }
-                else if (index === 1 && splitLabel.length >= 3 && str.includes('].[')) {
+                else if (index === 1 && splitLabel.length >= 3 && str.includes('.')) {
                     let splitStr = str.split(' ');
                     splitStr = splitStr.map(str => {
                         if (str.length >= LABEL_LENGTH_LIMIT) {

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -303,9 +303,19 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
         if (cell.value != null && cell.value.label != null) {
             let hasWindowsEOL = cell.value.label.includes('\r\n');
             let splitLabel = cell.value.label.split(/\r\n|\n/);
-            let cellLabel = splitLabel.map(str => {
+            let cellLabel = splitLabel.map((str, index) => {
                 let label = '';
-                label += str;
+
+                if (index === 0) {
+                    label += str.replace(/\(([^)]+)\)/g, '');
+                }
+                else if (index === 2 && splitLabel.length >= 3) {
+                    debugger;
+                    console.log(str);
+                }
+                else {
+                    label += str;
+                }
 
                 return label;
             });
@@ -525,7 +535,7 @@ azdataQueryPlan.prototype.adjustGraphNodeHorizontalPositions = function (node) {
     Object.keys(levelsTable).map(key => {
         for (let levelNodeIndex = 1; levelNodeIndex < levelsTable[key].length; ++levelNodeIndex) {
             let previousNode = levelsTable[key][levelNodeIndex - 1];
-            let currentNode = levelsTable[key][levelNodeIndex]
+            let currentNode = levelsTable[key][levelNodeIndex];
 
             let previousLabel = previousNode.label.split(/\r\n|\n/).filter(str => str.length > 20);
             if (previousLabel.length !== 0) {

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -562,10 +562,26 @@ azdataQueryPlan.prototype.adjustGraphNodeHorizontalPositions = function (node) {
 
             let previousLabel = previousNode.label.split(/\r\n|\n/).filter(str => str.length > 20);
             if (previousLabel.length !== 0) {
+                let longestString = '';
+                let labelPartitions = currentNode.label.split(/\r\n|\n/g);
+                labelPartitions.forEach(str => {
+                    if (longestString.length < str.length) {
+                        longestString = str;
+                    }
+                });
+
+                var size = mxUtils.getSizeForString(longestString.substring(0, LABEL_LENGTH_LIMIT),
+                    mxConstants.DEFAULT_FONTSIZE,
+                    mxConstants.DEFAULT_FONTFAMILY,
+                    undefined,
+                    mxConstants.DEFAULT_FONTSTYLE);
+
                 let distanceFromPreviousNode = currentNode.position.x - previousNode.position.x;
+
                 if (distanceFromPreviousNode <= STANDARD_NODE_DISTANCE) {
-                    let shiftToRightAmount = IDEAL_LONG_LABEL_NODE_DISTANCE - distanceFromPreviousNode;
+                    let shiftToRightAmount = Math.max(size.width, IDEAL_LONG_LABEL_NODE_DISTANCE) - distanceFromPreviousNode;
                     currentNode.position.x += shiftToRightAmount;
+                    console.log(shiftToRightAmount);
 
                     this.shiftParentAndChildNodePositionsHorizontally(currentNode.parent, shiftToRightAmount);
                 }

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -322,7 +322,7 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
             let cellLabel = splitLabel.map((str, index) => {
                 let label = '';
 
-                if (index === 0) {
+                if (index === 0 && !cell.value.icon?.includes('columnstore')) {
                     // This regex removes any text contained in parenthesis in the operation name
                     // i.e. "Clustered Index Seek (Clustered)" becomes "Clustered Index Seek"
                     label += str.replace(/\(([^)]+)\)/g, '');

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -302,6 +302,16 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
     graph.convertValueToString = function (cell) {
         if (cell.value != null && cell.value.label != null) {
             let hasWindowsEOL = cell.value.label.includes('\r\n');
+            const joinStrings = (strArray) => {
+                if (hasWindowsEOL) {
+                    return strArray.join('\r\n');
+                }
+                else {
+                    return strArray.join('\n');
+                }
+            };
+
+
             let splitLabel = cell.value.label.split(/\r\n|\n/);
             let cellLabel = splitLabel.map((str, index) => {
                 let label = '';
@@ -309,9 +319,18 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
                 if (index === 0) {
                     label += str.replace(/\(([^)]+)\)/g, '');
                 }
-                else if (index === 2 && splitLabel.length >= 3) {
-                    debugger;
-                    console.log(str);
+                else if (index === 1 && splitLabel.length >= 3 && str.includes('].[')) {
+                    let splitStr = str.split(' ');
+                    splitStr = splitStr.map(str => {
+                        if (str.length >= 38) {
+                            return str.substring(0, 35) + '...';
+                        }
+                        else {
+                            return str;
+                        }
+                    });
+                    
+                    label += joinStrings(splitStr);
                 }
                 else {
                     label += str;
@@ -320,12 +339,7 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
                 return label;
             });
 
-            if (hasWindowsEOL) {
-                cellLabel = cellLabel.join('\r\n');
-            }
-            else {
-                cellLabel = cellLabel.join('\n');
-            }
+            cellLabel = joinStrings(cellLabel);
 
             return cellLabel;
         }
@@ -450,7 +464,7 @@ azdataQueryPlan.prototype.placeGraphNodes = function () {
     // for entire showplan. For starters, we set this to 100px. However,
     // if a node has label with many lines, this value will be updated to 
     // better fit that node.
-    this.spacingY = 100;
+    this.spacingY = 105;
 
     // Getting the node padding values from SSMS.
     this.paddingX = GRAPH_PADDING_RIGHT;
@@ -792,7 +806,7 @@ azdataQueryPlan.prototype.getPolygonPerimeter = function (cell) {
     return points;
 }
 
-const NODE_HEIGHT = 100;
+const NODE_HEIGHT = 105;
 const NODE_WIDTH = 100;
 
 /**

--- a/src/js/azdata/view/azDataGraph.js
+++ b/src/js/azdata/view/azDataGraph.js
@@ -118,17 +118,18 @@ azdataGraph.prototype.getStyledTooltipForCell = function (cell) {
 
         // tooltip heading for vertices only
         if (!cell.edge) {
-            tooltip += `<div style=\"${centerText}\"><span style=\"${boldText}\">${cell.value.tooltipTitle}</span></div>`;
-            if(cell.value.description){
+            let tooltipTitle = this.truncateTooltipTitle(cell.value.tooltipTitle);
+            tooltip += `<div style=\"${centerText}\"><span style=\"${boldText}\">${tooltipTitle}</span></div>`;
+            if (cell.value.description) {
                 tooltip += `<div style=\"${headerBottomMargin} ${headerTopMargin}\"><span>${cell.value.description}</span></div>`;
             }
-        } 
+        }
 
         // tooltip body
         let startIndex = cell.edge ? 0 : 1; // first index for vertices contains footer label, so we can skip for vertices.
         for (var i = startIndex; i < cell.value.metrics.length; ++i) {
-            if(cell.value.metrics[i].isLongString){ // Skipping all strings as they go to the bottom of tooltip
-                continue; 
+            if (cell.value.metrics[i].isLongString) { // Skipping all strings as they go to the bottom of tooltip
+                continue;
             }
             tooltip += `<div style=\"${tooltipLineHeight}\">`;
 
@@ -149,16 +150,43 @@ azdataGraph.prototype.getStyledTooltipForCell = function (cell) {
             cell.value.metrics.filter(m => m.isLongString).forEach(m => {
                 tooltip += '<hr />';
                 tooltip += `<div style=\"${footerTopMargin}\"><span style=\"${boldText}\">${m.name}</span></div>`;
-                tooltip += `<div><span>${m.value.replace(/(\r\n|\n|\r)/gm, " ")}</span></div>`; // Removing all line breaks as they look bad in tooltips
+
+                let metricLabel = m.value.replace(/(\r\n|\n|\r)/gm, " ");
+                if (metricLabel.length > 103) {
+                    metricLabel = metricLabel.substring(0, 100) + '...';
+                }
+                tooltip += `<div><span>${metricLabel}</span></div>`; // Removing all line breaks as they look bad in tooltips
             })
         }
 
         tooltip += '</div>';
-        
+
         return tooltip;
     }
 
     return azdataGraph.prototype.getTooltipForCell.apply(this, arguments); // "supercall"
+};
+
+azdataGraph.prototype.truncateTooltipTitle = function (title) {
+    let hasWindowsEOL = title.includes('\r\n');
+    let titleSegments = hasWindowsEOL ? title.split('\r\n') : title.split('\n');
+    let truncatedTitleSegments = titleSegments.map(segment => {
+        if (segment.length > 50) {
+            return segment.substring(0, 50) + '...';
+        }
+        else {
+            return segment;
+        }
+    });
+
+    if (hasWindowsEOL) {
+        title = truncatedTitleSegments.join('\r\n');
+    }
+    else {
+        title = truncatedTitleSegments.join('\n');
+    }
+
+    return title;
 };
 
 /**
@@ -191,7 +219,7 @@ azdataGraph.prototype.graphEventHandler = function (sender, event, eventCallback
  * eventType - The event type (i.e. 'click') that should trigger the callback
  * callback - The callback function that is executed by the event listener.
  */
- azdataGraph.prototype.addDomEventListener = function (element, eventType, eventCallback) {
+azdataGraph.prototype.addDomEventListener = function (element, eventType, eventCallback) {
     mxEvent.addListener(element, eventType, (e) => {
         if (eventCallback) {
             eventCallback();

--- a/src/js/azdata/view/azDataGraph.js
+++ b/src/js/azdata/view/azDataGraph.js
@@ -142,7 +142,7 @@ azdataGraph.prototype.getStyledTooltipForCell = function (cell) {
                 tooltip += `<hr />`;
             }
 
-            tooltip += `</div>`
+            tooltip += `</div>`;
         }
 
         // tooltip footer for vertices only


### PR DESCRIPTION
This PR adjusts how labels appear, so that they don't overlap with others.

Things to note:
- An index name will be truncated if it exceeds the length of 38 characters.
- The first half of an index name will appear on one line, and the second half will appear on the next line.
- In the image, the bottom two nodes have text in parenthesis like, "(Clustered)". In the new version that has been removed, so labels that appeared like the following, "Clustered Index Seek (Clustered)", now appear as "Clustered Index Seek".
- If a node has a columnstore icon, then additional information like (Clustered) and (NonClustered) will not be removed to help differentiate.

Before:
![image](https://user-images.githubusercontent.com/87730006/170331325-ad7e8221-a45e-41d5-94cd-c0a60df3f2aa.png)

After:
![image](https://user-images.githubusercontent.com/87730006/170331167-72db8b73-7a5d-41eb-a5fa-c31469ecda7c.png)
