### PR TITLE
Expand and Collapse Execution Plan Nodes

### DIFF
--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -369,17 +369,18 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
         return this.model.getOutgoingEdges(cell).length > 0;
     };
 
+    let self = this;
     // Defines the position for the folding icon
     graph.cellRenderer.getControlBounds = function (state) {
         if (state.control != null) {
-            let oldScale = state.control.scale;
-            let w = state.control.bounds.width / oldScale;
-            let h = state.control.bounds.height / oldScale;
-            let s = state.view.scale;
+            let controlScale = state.control.scale;
+            let boundWidth = state.control.bounds.width / controlScale;
+            let boundHeight = state.control.bounds.height / controlScale;
+            let scale = self.graph.view.getScale();
 
-            return new mxRectangle(state.x + state.width - 20 * s,
-                state.y * s,
-                w * s, h * s);
+            return new mxRectangle(state.x + state.width - 20 * scale,
+                state.cell.geometry.y * scale,
+                boundWidth * scale, boundHeight * scale);
         }
 
         return null;

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -163,7 +163,6 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
     this.polygonRoots = [];
     this.drawnPolygons = [];
     this.badges = [];
-    this.isCompareMode = false;
     mxEvent.addListener(window, 'unload', mxUtils.bind(this, function () {
         this.destroy();
     }));
@@ -388,10 +387,6 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
     };
 
     graph.foldCells = function (collapse, recurse, cells) {
-        if (self.isCompareMode) {
-            return;
-        }
-
         this.model.beginUpdate();
         try {
             toggleSubtree(this, cells[0], !collapse);
@@ -525,9 +520,20 @@ azdataQueryPlan.prototype.placeGraphNodes = function () {
     this.setNodePositionRecursive(this.queryPlanGraph, startX, startY);
 }
 
-azdataQueryPlan.prototype.setCompareMode = function (isCompareMode) {
-    this.isCompareMode = isCompareMode;
-}
+azdataQueryPlan.prototype.disableNodeCollapse = function (disableCollapse) {
+    const allVertices = this.graph.model.getChildCells(this.graph.getDefaultParent()).filter(v => v?.vertex);
+    allVertices.forEach(v => {
+        let state = this.graph.view.getState(v);
+        if (disableCollapse && state.control != null && state.control.node != null) {
+            state.control.node.style.visibility = 'hidden';
+        }
+        else if (state.control != null && state.control.node != null) {
+            if (this.graph.model.getOutgoingEdges(cell).length > 0) {
+                state.control.node.style.visibility = 'visible';
+            }
+        }
+    });
+};
 
 azdataQueryPlan.prototype.setNodePositionRecursive = function (node, x, y) {
 

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -163,6 +163,7 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
     this.polygonRoots = [];
     this.drawnPolygons = [];
     this.badges = [];
+    this.isCompareMode = false;
     mxEvent.addListener(window, 'unload', mxUtils.bind(this, function () {
         this.destroy();
     }));
@@ -387,6 +388,10 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
     };
 
     graph.foldCells = function (collapse, recurse, cells) {
+        if (isCompareMode) {
+            return;
+        }
+
         this.model.beginUpdate();
         try {
             toggleSubtree(this, cells[0], !collapse);
@@ -518,6 +523,10 @@ azdataQueryPlan.prototype.placeGraphNodes = function () {
 
     // Recursively layout all nodes starting with root
     this.setNodePositionRecursive(this.queryPlanGraph, startX, startY);
+}
+
+azdataQueryPlan.prototype.setCompareMode = function (isCompareMode) {
+    this.isCompareMode = isCompareMode;
 }
 
 azdataQueryPlan.prototype.setNodePositionRecursive = function (node, x, y) {

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -377,8 +377,8 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
             let h = state.control.bounds.height / oldScale;
             let s = state.view.scale;
 
-            return new mxRectangle(state.x + state.width / 2 - w / 2 * s,
-                state.y + state.height + 20 * s - h / 2 * s,
+            return new mxRectangle(state.x + state.width - 20 * s,
+                state.y * s,
                 w * s, h * s);
         }
 

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -780,7 +780,7 @@ azdataQueryPlan.prototype.addBadges = function (cell, badgeIconPaths) {
             this.badges.push(img);
         });
     }
-};
+}
 
 azdataQueryPlan.prototype.redrawBadges = function () {
     this.badges.forEach(b => {

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -524,13 +524,15 @@ azdataQueryPlan.prototype.disableNodeCollapse = function (disableCollapse) {
     const allVertices = this.graph.model.getChildCells(this.graph.getDefaultParent()).filter(v => v?.vertex);
     allVertices.forEach(v => {
         let state = this.graph.view.getState(v);
-        if (disableCollapse && state.control != null && state.control.node != null) {
+        if ((state.control == null || state.control.node == null)) {
+            return;
+        }
+
+        if (disableCollapse) {
             state.control.node.style.visibility = 'hidden';
         }
-        else if (state.control != null && state.control.node != null) {
-            if (this.graph.model.getOutgoingEdges(cell).length > 0) {
-                state.control.node.style.visibility = 'visible';
-            }
+        else if (this.graph.model.getOutgoingEdges(v).length > 0) {
+            state.control.node.style.visibility = 'visible';
         }
     });
 };

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -388,7 +388,7 @@ azdataQueryPlan.prototype.init = function (container, iconPaths, badgeIconPaths)
     };
 
     graph.foldCells = function (collapse, recurse, cells) {
-        if (isCompareMode) {
+        if (self.isCompareMode) {
             return;
         }
 

--- a/test/queryplan/comparePlanModeWithNoFolding.html
+++ b/test/queryplan/comparePlanModeWithNoFolding.html
@@ -25,7 +25,7 @@
 			var badgePaths = getBadgePaths(imageBasePath);
 
 			var azdataGraph = new azdataQueryPlan(container, graph, iconPaths, badgePaths);
-			azdataGraph.setCompareMode(true);
+			azdataGraph.disableNodeCollapse(true);
             let cell = azdataGraph.graph.model.getCell('element-6');
 			var samplePolygon = azdataGraph.drawPolygon(
 				cell,

--- a/test/queryplan/comparePlanModeWithNoFolding.html
+++ b/test/queryplan/comparePlanModeWithNoFolding.html
@@ -1,0 +1,73 @@
+<!--
+  Test page for manually testing query plan polygons.
+
+  This test page covers an edge case where the bottom side of the polygon
+  doesn't display correctly.
+-->
+<html>
+
+<head>
+	<title>Query Plan test</title>
+	<script type="text/javascript">
+		mxForceIncludes = true;
+		mxBasePath = '../../src';
+	</script>
+	<script type="text/javascript" src="./src/js/graph2.js"></script>
+	<script type="text/javascript" src="../../src/js/mxClient.js"></script>
+	<script type="text/javascript" src="./src/js/queryPlanSetup.js"></script>
+	<script type="text/javascript">
+
+		function main(container) {
+			var graph = getGraph();
+
+			var imageBasePath = './icons/';
+			var iconPaths = getIconPaths(imageBasePath);
+			var badgePaths = getBadgePaths(imageBasePath);
+
+			var azdataGraph = new azdataQueryPlan(container, graph, iconPaths, badgePaths);
+			azdataGraph.setCompareMode(true);
+            let cell = azdataGraph.graph.model.getCell('element-6');
+			var samplePolygon = azdataGraph.drawPolygon(
+				cell,
+				"rgba(75, 168, 255, 0.1)",
+				"rgba(75, 168, 255)",
+				2
+			);
+
+            cell = azdataGraph.graph.model.getCell('element-55');
+			var samplePolygon = azdataGraph.drawPolygon(
+				cell,
+				"rgba(12, 173, 171, 0.1)",
+				"rgba(12, 173, 171)",
+				2
+			);
+
+			cell = azdataGraph.graph.model.getCell('element-58');
+			var samplePolygon = azdataGraph.drawPolygon(
+				cell,
+				"rgba(236, 0, 140, 0.1)",
+				"rgba(236, 0, 140)",
+				2
+			)
+		};
+
+	</script>
+	<style>
+		#graphContainer {
+			position: relative;
+			overflow: scroll;
+			width: 1000px;
+			height: 1000px;
+			cursor: default;
+			border: 1px solid;
+			margin-top: 100px;
+			margin-left: 100px;
+		}
+	</style>
+</head>
+
+<body onload="main(document.getElementById('graphContainer'))">
+	<div id="graphContainer"></div>
+</body>
+
+</html>


### PR DESCRIPTION
This PR adds functionality to collapse/expand execution plan operation nodes.

Expanded:
![image](https://user-images.githubusercontent.com/87730006/176795360-b7f387f6-1619-4d43-a29d-dc7e67c04159.png)

Collapsed:
![image](https://user-images.githubusercontent.com/87730006/176795403-10b5ed02-5409-4736-8388-812019414d10.png)

This PR also features a toggle that can nodes from collapsing and expanding:
![image](https://user-images.githubusercontent.com/87730006/177418763-fcc75aa1-5a9c-4edd-a063-3bbf559cf286.png)
