### PR TITLE
Collapse and Expand Plans when they're being compared

### DIFF
--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -893,7 +893,6 @@ azdataQueryPlan.prototype.getPolygonPerimeter = function (cell) {
         return [];
     }
 
-    debugger;
     let points = [];
     points = points.concat(this.getLeftSidePoints(cell));
     let rightSidePoints = this.getRightSidePoints(cell);
@@ -988,16 +987,27 @@ azdataQueryPlan.prototype.getRightSidePoints = function (cell) {
         let leaf = leafs[leafIndex];
         let additionalRightSideSpacing = this.calcAdditionalSpacingForNode(leaf);
 
-        debugger;
         let lastLeaf = undefined;
         if (leafIndex > 0) {
             lastLeaf = leafs[leafIndex - 1];
         }
 
-        let leafPositionX = leaf.geometry.x;
-        if (lastLeaf !== undefined && leafPositionX < lastLeaf.geometry.x) {
-            leafPositionX = lastLeaf.geometry.x;
+        let nextLeaf = undefined;
+        if (leafIndex + 1 < leafs.length) {
+            nextLeaf = leafs[leafIndex + 1];
         }
+
+        let lastLeafPositionX = -1;
+        if (lastLeaf) {
+            lastLeafPositionX = lastLeaf.geometry.x;
+        }
+
+        let nextLeafPositionX = -1;
+        if (nextLeaf) {
+            nextLeafPositionX = nextLeaf.geometry.x;
+        }
+        
+        let leafPositionX = Math.min(Math.max(lastLeafPositionX, leaf.geometry.x), Math.max(nextLeafPositionX, leaf.geometry.x));
 
         points.push({ x: leafPositionX + NODE_WIDTH + additionalRightSideSpacing, y: leaf.geometry.y + NODE_HEIGHT });
         points.push({ x: leafPositionX + NODE_WIDTH + additionalRightSideSpacing, y: leaf.geometry.y });

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -400,6 +400,7 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
         try {
             toggleSubtree(this, cells[0], !collapse);
             this.model.setCollapsed(cells[0], collapse);
+            self.renderPolygons();
         }
         finally {
             this.model.endUpdate();
@@ -887,6 +888,11 @@ azdataQueryPlan.prototype.renderPolygons = function () {
  * @returns an array of points
  */
 azdataQueryPlan.prototype.getPolygonPerimeter = function (cell) {
+    if (!cell.isVisible()) {
+        return [];
+    }
+
+    debugger;
     let points = [];
     points = points.concat(this.getLeftSidePoints(cell));
     let rightSidePoints = this.getRightSidePoints(cell);
@@ -1010,7 +1016,7 @@ azdataQueryPlan.prototype.getLeafNodes = function (cell) {
     while (stack.length !== 0) {
         let entry = stack.pop();
 
-        if (entry.value.children.length === 0) {
+        if (entry.value.children.length === 0 || !this.isChildCellVisible(entry)) {
             if (entry.geometry.y in leafNodeTable) {
                 let previouslyCachedEntry = leafNodeTable[entry.geometry.y];
                 if (entry.geometry.x > previouslyCachedEntry.geometry.x) {
@@ -1022,14 +1028,21 @@ azdataQueryPlan.prototype.getLeafNodes = function (cell) {
             }
         }
 
-        for (let nodeIndex = 0; nodeIndex < entry.value.children.length; ++nodeIndex) {
-            stack.push(this.graph.model.getCell(entry.value.children[nodeIndex].id));
+        for (let nodeIndex = 0; nodeIndex < entry.value.children.length && this.isChildCellVisible(entry); ++nodeIndex) {
+            let childCell = this.graph.model.getCell(entry.value.children[nodeIndex].id);
+            stack.push(childCell);
         }
     }
 
     let leafNodes = Object.keys(leafNodeTable).map(key => leafNodeTable[key]).reverse();
 
     return leafNodes;
+};
+
+azdataQueryPlan.prototype.isChildCellVisible = function (vertex) {
+    let childCell = this.graph.model.getCell(vertex.value.children[0].id);
+    
+    return childCell.isVisible();
 };
 
 

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -1040,8 +1040,11 @@ azdataQueryPlan.prototype.getLeafNodes = function (cell) {
 };
 
 azdataQueryPlan.prototype.isChildCellVisible = function (vertex) {
+    if (vertex.value.children.length === 0) {
+        return false;
+    }
+
     let childCell = this.graph.model.getCell(vertex.value.children[0].id);
-    
     return childCell.isVisible();
 };
 

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -980,20 +980,20 @@ azdataQueryPlan.prototype.getBottomSideNodes = function (cell, polygonRightSideC
  */
 azdataQueryPlan.prototype.getRightSidePoints = function (cell) {
     let points = [];
-    let leafs = this.getLeafNodes(cell);
+    let leafNodes = this.getLeafNodes(cell);
 
-    for (let leafIndex = 0; leafIndex < leafs.length; ++leafIndex) {
-        let leaf = leafs[leafIndex];
+    for (let leafIndex = 0; leafIndex < leafNodes.length; ++leafIndex) {
+        let leaf = leafNodes[leafIndex];
         let additionalRightSideSpacing = this.calcAdditionalSpacingForNode(leaf);
 
         let lastLeaf = undefined;
         if (leafIndex > 0) {
-            lastLeaf = leafs[leafIndex - 1];
+            lastLeaf = leafNodes[leafIndex - 1];
         }
 
         let nextLeaf = undefined;
-        if (leafIndex + 1 < leafs.length) {
-            nextLeaf = leafs[leafIndex + 1];
+        if (leafIndex + 1 < leafNodes.length) {
+            nextLeaf = leafNodes[leafIndex + 1];
         }
 
         let lastLeafPositionX = -1;

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -400,11 +400,12 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
         try {
             toggleSubtree(this, cells[0], !collapse);
             this.model.setCollapsed(cells[0], collapse);
-            self.renderPolygons();
         }
         finally {
             this.model.endUpdate();
         }
+
+        self.renderPolygons();
     };
 
     graph.getTooltipForCell = azdataGraph.prototype.getStyledTooltipForCell;
@@ -985,11 +986,21 @@ azdataQueryPlan.prototype.getRightSidePoints = function (cell) {
 
     for (let leafIndex = 0; leafIndex < leafs.length; ++leafIndex) {
         let leaf = leafs[leafIndex];
-
         let additionalRightSideSpacing = this.calcAdditionalSpacingForNode(leaf);
 
-        points.push({ x: leaf.geometry.x + NODE_WIDTH + additionalRightSideSpacing, y: leaf.geometry.y + NODE_HEIGHT });
-        points.push({ x: leaf.geometry.x + NODE_WIDTH + additionalRightSideSpacing, y: leaf.geometry.y });
+        debugger;
+        let lastLeaf = undefined;
+        if (leafIndex > 0) {
+            lastLeaf = leafs[leafIndex - 1];
+        }
+
+        let leafPositionX = leaf.geometry.x;
+        if (lastLeaf !== undefined && leafPositionX < lastLeaf.geometry.x) {
+            leafPositionX = lastLeaf.geometry.x;
+        }
+
+        points.push({ x: leafPositionX + NODE_WIDTH + additionalRightSideSpacing, y: leaf.geometry.y + NODE_HEIGHT });
+        points.push({ x: leafPositionX + NODE_WIDTH + additionalRightSideSpacing, y: leaf.geometry.y });
     }
 
     return points;

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -400,12 +400,11 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
         try {
             toggleSubtree(this, cells[0], !collapse);
             this.model.setCollapsed(cells[0], collapse);
+            self.renderPolygons();
         }
         finally {
             this.model.endUpdate();
         }
-
-        self.renderPolygons();
     };
 
     graph.getTooltipForCell = azdataGraph.prototype.getStyledTooltipForCell;

--- a/test/queryplan/comparePlanModeWithFolding.html
+++ b/test/queryplan/comparePlanModeWithFolding.html
@@ -1,0 +1,80 @@
+<!--
+  Test page for manually testing query plan polygons.
+
+  This test page is for testing the collapse/expand node functionality when an execution plan
+  is in comparison mode.
+-->
+<html>
+
+<head>
+	<title>Query Plan test</title>
+	<script type="text/javascript">
+		mxForceIncludes = true;
+		mxBasePath = '../../src';
+	</script>
+	<script type="text/javascript" src="./src/js/graph2.js"></script>
+	<script type="text/javascript" src="../../src/js/mxClient.js"></script>
+	<script type="text/javascript" src="./src/js/queryPlanSetup.js"></script>
+	<script type="text/javascript">
+
+		function main(container) {
+			var graph = getGraph();
+
+			var imageBasePath = './icons/';
+			var iconPaths = getIconPaths(imageBasePath);
+			var badgePaths = getBadgePaths(imageBasePath);
+			var collapseExpandPaths = getCollapseExpandPaths(imageBasePath);
+
+			let queryPlanConfiguration = {
+				container: container,
+				queryPlanGraph: graph,
+				iconPaths: iconPaths,
+				badgeIconPaths: badgePaths,
+				expandCollapsePaths: undefined
+			};
+			var azdataGraph = new azdataQueryPlan(queryPlanConfiguration);
+            let cell = azdataGraph.graph.model.getCell('element-6');
+			var samplePolygon = azdataGraph.drawPolygon(
+				cell,
+				"rgba(75, 168, 255, 0.1)",
+				"rgba(75, 168, 255)",
+				2
+			);
+
+            cell = azdataGraph.graph.model.getCell('element-55');
+			var samplePolygon = azdataGraph.drawPolygon(
+				cell,
+				"rgba(12, 173, 171, 0.1)",
+				"rgba(12, 173, 171)",
+				2
+			);
+
+			cell = azdataGraph.graph.model.getCell('element-58');
+			var samplePolygon = azdataGraph.drawPolygon(
+				cell,
+				"rgba(236, 0, 140, 0.1)",
+				"rgba(236, 0, 140)",
+				2
+			)
+		};
+
+	</script>
+	<style>
+		#graphContainer {
+			position: relative;
+			overflow: scroll;
+			width: 1000px;
+			height: 1000px;
+			cursor: default;
+			border: 1px solid;
+			margin-top: 100px;
+			margin-left: 100px;
+		}
+	</style>
+</head>
+
+<body onload="main(document.getElementById('graphContainer'))">
+	<div id="graphContainer"></div>
+</body>
+
+</html>


### PR DESCRIPTION
This PR adds functionality to expand/collapse execution plans when they're being compared.

Fully Expanded:
![image](https://user-images.githubusercontent.com/87730006/180141456-b2ecbd6d-dd41-434c-8568-856eb1c1ca2f.png)

Fully Collapsed:
![image](https://user-images.githubusercontent.com/87730006/180141497-09c54b8e-c48c-4e07-b3b8-3f7890e3ed08.png)

Partly Collapsed
![image](https://user-images.githubusercontent.com/87730006/180141698-1613bafd-8129-47cc-a643-8223c84ad149.png)
![image](https://user-images.githubusercontent.com/87730006/180141819-1c2342b3-01c7-4c87-828d-41be3d65529e.png)
![image](https://user-images.githubusercontent.com/87730006/180141753-eef982ec-169f-4852-8676-d8d3c7a7ccf5.png)

