### PR TITLE
Adds key mapping: space key collapses node, enter key expands node

### DIFF
--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -305,8 +305,8 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
         // undefined is for the middle parameter since the overwritten definition of foldCells doesn't reference it.
         this.graph.foldCells(collapse, undefined, [currentCell]);
     };
-    this.keyHandler.bindKey(spaceKey, toggleNodeCollapse);
     this.keyHandler.bindKey(enterKey, toggleNodeCollapse);
+    this.keyHandler.bindKey(spaceKey, toggleNodeCollapse);
 
     var style = graph.getStylesheet().getDefaultEdgeStyle();
     style[mxConstants.STYLE_EDGE] = mxEdgeStyle.ElbowConnector;

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -296,6 +296,26 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
     };
     this.keyHandler.bindKey(arrowDownKey, selectBottom);
 
+    const enterKey = 13;
+    const expandNode = (evt) => {
+        const collapse = false;
+        const currentCell = this.graph.getSelectionCell();
+
+        // undefined for the middle parameter since it is unused in the method definition for foldCells
+        this.graph.foldCells(collapse, undefined, [currentCell]);
+    };
+    this.keyHandler.bindKey(enterKey, expandNode);
+    
+    const spaceKey = 32;
+    const collapseNode = (evt) => {
+        const collapse = true;
+        const currentCell = this.graph.getSelectionCell();
+
+        // undefined for the middle parameter since it is unused in the method definition for foldCells
+        this.graph.foldCells(collapse, undefined, [currentCell]);
+    };
+    this.keyHandler.bindKey(spaceKey, collapseNode);
+
     var style = graph.getStylesheet().getDefaultEdgeStyle();
     style[mxConstants.STYLE_EDGE] = mxEdgeStyle.ElbowConnector;
 

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -296,25 +296,15 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
     };
     this.keyHandler.bindKey(arrowDownKey, selectBottom);
 
-    const enterKey = 13;
-    const expandNode = (evt) => {
-        const collapse = false;
+    const spaceKey = 32;    
+    const toggleNodeCollapse = (evt) => {
         const currentCell = this.graph.getSelectionCell();
+        const collapse = !currentCell.collapsed;
 
         // undefined for the middle parameter since it is unused in the method definition for foldCells
         this.graph.foldCells(collapse, undefined, [currentCell]);
     };
-    this.keyHandler.bindKey(enterKey, expandNode);
-    
-    const spaceKey = 32;
-    const collapseNode = (evt) => {
-        const collapse = true;
-        const currentCell = this.graph.getSelectionCell();
-
-        // undefined for the middle parameter since it is unused in the method definition for foldCells
-        this.graph.foldCells(collapse, undefined, [currentCell]);
-    };
-    this.keyHandler.bindKey(spaceKey, collapseNode);
+    this.keyHandler.bindKey(spaceKey, toggleNodeCollapse);
 
     var style = graph.getStylesheet().getDefaultEdgeStyle();
     style[mxConstants.STYLE_EDGE] = mxEdgeStyle.ElbowConnector;

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -296,7 +296,8 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
     };
     this.keyHandler.bindKey(arrowDownKey, selectBottom);
 
-    const spaceKey = 32;    
+    const enterKey = 13;
+    const spaceKey = 32;
     const toggleNodeCollapse = (evt) => {
         const currentCell = this.graph.getSelectionCell();
         const collapse = !currentCell.collapsed;
@@ -305,6 +306,7 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
         this.graph.foldCells(collapse, undefined, [currentCell]);
     };
     this.keyHandler.bindKey(spaceKey, toggleNodeCollapse);
+    this.keyHandler.bindKey(enterKey, toggleNodeCollapse);
 
     var style = graph.getStylesheet().getDefaultEdgeStyle();
     style[mxConstants.STYLE_EDGE] = mxEdgeStyle.ElbowConnector;

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -301,7 +301,7 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
         const currentCell = this.graph.getSelectionCell();
         const collapse = !currentCell.collapsed;
 
-        // undefined for the middle parameter since it is unused in the method definition for foldCells
+        // undefined is for the middle parameter since the overwritten definition of foldCells doesn't reference it.
         this.graph.foldCells(collapse, undefined, [currentCell]);
     };
     this.keyHandler.bindKey(spaceKey, toggleNodeCollapse);


### PR DESCRIPTION
This PR adds keyboard shortcuts to collapse and expand nodes.

* Space/Enter key - Collapses or expands the currently selected node depending on it's collapsed state.