### PR TITLE
Fixes bug around undefined cost and row count display strings

### DIFF
--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -372,7 +372,7 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
 
             const costContainer = document.createElement('div');
             costContainer.setAttribute('class', 'graph-cell-cost');
-            costContainer.innerHTML = cell.value.costDisplayString;
+            costContainer.innerHTML = cell.value.costDisplayString ?? '';
             cellBodyContainer.appendChild(costContainer);
 
             const iconContainer = document.createElement('div');
@@ -420,7 +420,7 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
             // Adding output row count to the left of graph cell;
             const rows = document.createElement('div');
             rows.setAttribute('class', 'graph-cell-row-count');
-            rows.innerText = cell.value.rowCountDisplayString;
+            rows.innerText = cell.value.rowCountDisplayString ?? '';
             cellContainer.appendChild(rows);
 
             cellBodyContainer.ariaLabel = 'Level 1 Select Cost: 9% expanded'


### PR DESCRIPTION
This PR fixes a bug around "undefined" labels appearing above and to the left of an icon when a query execution plan doesn't have valid values for cost and row count display string properties.

Before:
![image](https://user-images.githubusercontent.com/87730006/186276370-524e218f-4658-40c4-aea6-32c8e7fa6e1a.png)

After:
![image](https://user-images.githubusercontent.com/87730006/186276407-d7a39e27-61b2-4c2f-b496-45b46fe8b5b1.png)
