### PR TITLE
Exposes hook for clearing expensive operator highlighting

### DIFF
--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -1237,8 +1237,16 @@ azdataQueryPlan.prototype.isChildCellVisible = function (vertex) {
     return childCell.isVisible();
 };
 
+azdataQueryPlan.prototype.clearExpensiveOperatorHighlighting = function (node) {
+    if (this.expensiveCellHighlighter) {
+        this.expensiveCellHighlighter.destroy();
+    }
+
+    this.expensiveCellHighlighter = undefined;
+};
+
 azdataQueryPlan.prototype.highlightExpensiveOperator = function (costPredicate) {
-    const HIGHLIGHTER_COLOR = '#ff0000';
+    const HIGHLIGHTER_COLOR = '#FFA500'; // Orange
     const STROKE_WIDTH = 1;
 
     const expensiveNode = this.findExpensiveOperator(costPredicate);
@@ -1247,8 +1255,8 @@ azdataQueryPlan.prototype.highlightExpensiveOperator = function (costPredicate) 
     }
 
     const expensiveCell = this.graph.model.getCell(expensiveNode.id);
-    const cellHighlighter = new mxCellHighlight(this.graph, HIGHLIGHTER_COLOR, STROKE_WIDTH);
-    cellHighlighter.highlight(this.graph.view.getState(expensiveCell));
+    this.expensiveCellHighlighter = new mxCellHighlight(this.graph, HIGHLIGHTER_COLOR, STROKE_WIDTH);
+    this.expensiveCellHighlighter.highlight(this.graph.view.getState(expensiveCell));
 };
 
 azdataQueryPlan.prototype.findExpensiveOperator = function (getCostValue) {

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -369,6 +369,7 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
         }
     });
 
+    let self = this;
     graph.convertValueToString = function (cell) {
         if (cell.value != null && cell.value.label != null) {
             const cellDivs = new Object();
@@ -454,7 +455,9 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
                     // undefined is for the middle parameter since the overwritten definition of foldCells doesn't reference it.
                     this.foldCells(collapse, undefined, [currentCell]);
                     currentCell.cellDivs.body.focus();
-
+                    if (!collapse) {
+                        self.redrawExpensiveOperatorHighlighting();
+                    }
                 });
             }
 
@@ -557,7 +560,6 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
         return false;
     };
 
-    let self = this;
     // Defines the position for the folding icon
     graph.cellRenderer.getControlBounds = function (state) {
         if (state.control != null) {
@@ -1237,12 +1239,19 @@ azdataQueryPlan.prototype.isChildCellVisible = function (vertex) {
     return childCell.isVisible();
 };
 
-azdataQueryPlan.prototype.clearExpensiveOperatorHighlighting = function (node) {
+azdataQueryPlan.prototype.clearExpensiveOperatorHighlighting = function () {
     if (this.expensiveCellHighlighter) {
         this.expensiveCellHighlighter.destroy();
     }
 
+    this.expensiveCell = undefined;
     this.expensiveCellHighlighter = undefined;
+};
+
+azdataQueryPlan.prototype.redrawExpensiveOperatorHighlighting = function () {
+    if (this.expensiveCell && this.expensiveCellHighlighter) {
+        this.expensiveCellHighlighter.highlight(this.graph.view.getState(this.expensiveCell));
+    }
 };
 
 azdataQueryPlan.prototype.highlightExpensiveOperator = function (costPredicate) {
@@ -1254,9 +1263,9 @@ azdataQueryPlan.prototype.highlightExpensiveOperator = function (costPredicate) 
         return;
     }
 
-    const expensiveCell = this.graph.model.getCell(expensiveNode.id);
+    this.expensiveCell = this.graph.model.getCell(expensiveNode.id);
     this.expensiveCellHighlighter = new mxCellHighlight(this.graph, HIGHLIGHTER_COLOR, STROKE_WIDTH);
-    this.expensiveCellHighlighter.highlight(this.graph.view.getState(expensiveCell));
+    this.expensiveCellHighlighter.highlight(this.graph.view.getState(this.expensiveCell));
 };
 
 azdataQueryPlan.prototype.findExpensiveOperator = function (getCostValue) {

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -486,6 +486,11 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
                     // undefined is for the middle parameter since the overwritten definition of foldCells doesn't reference it.
                     this.foldCells(collapse, undefined, [currentCell]);
                     cell.cellDivs.body.focus();
+                    
+                    if (!collapse) {
+                        self.redrawExpensiveOperatorHighlighting();
+                    }
+                    
                     evt.stopPropagation();
                     evt.preventDefault();
                 }

--- a/test/queryplan/queryPlanExpensiveOperatorHighlighting.html
+++ b/test/queryplan/queryPlanExpensiveOperatorHighlighting.html
@@ -2,7 +2,7 @@
   Test page for manually testing query plan polygons.
 
   This test page covers highlighting the most expensive operator found in a
-  query execution plan and then clearing it after 3 seconds.
+  query execution plan and then clearing it when the clear button is clicked.
 -->
 <html>
 
@@ -39,10 +39,11 @@
 				return node.elapsedTimeInMs;
 			});
 
-			// Tests clearing expensive operator highlighting after 3 seconds
-			setTimeout(function() {
+			// Tests clearing expensive operator highlighting
+			const clearButton = document.getElementById('clear-btn');
+			clearButton.addEventListener('click', () => {
 				azdataGraph.clearExpensiveOperatorHighlighting();
-			}, 3000);
+			});
 		};
 
 	</script>
@@ -62,6 +63,10 @@
 
 <body onload="main(document.getElementById('graphContainer'))">
 	<div id="graphContainer"></div>
+
+	<div id="buttonContainer" style="padding-top: 15px; padding-left: 100px">
+		<button type="button" id="clear-btn">Clear Operator Highlighting</button>
+	</div>
 </body>
 
 </html>

--- a/test/queryplan/queryPlanExpensiveOperatorHighlighting.html
+++ b/test/queryplan/queryPlanExpensiveOperatorHighlighting.html
@@ -2,7 +2,7 @@
   Test page for manually testing query plan polygons.
 
   This test page covers highlighting the most expensive operator found in a
-  query execution plan.
+  query execution plan and then clearing it after 3 seconds.
 -->
 <html>
 
@@ -38,6 +38,11 @@
 			azdataGraph.highlightExpensiveOperator((node) => {
 				return node.elapsedTimeInMs;
 			});
+
+			// Tests clearing expensive operator highlighting after 3 seconds
+			setTimeout(function() {
+				azdataGraph.clearExpensiveOperatorHighlighting();
+			}, 3000);
 		};
 
 	</script>


### PR DESCRIPTION
* Renames test file from "QueryPlanWithCostInformation" to "queryPlanExpensiveOperatorHighlighting"
* Test file uses the new clearing method to clear highlighting when the clear button is clicked. 
![image](https://user-images.githubusercontent.com/87730006/187779676-f6d1a815-2529-4ba4-b21b-fd6fcbb0a73c.png)


Before clearing highlighting:
![image](https://user-images.githubusercontent.com/87730006/187773336-bda87c7f-2fcd-40a1-a6f7-25c02ff9d8c1.png)

After clearing highlighting:
![image](https://user-images.githubusercontent.com/87730006/187773501-e329a308-359d-46c7-9480-896201723417.png)