### PR TITLE
Adjusts expensive operator outline color for query execution plans

### DIFF
--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -1266,7 +1266,7 @@ azdataQueryPlan.prototype.redrawExpensiveOperatorHighlighting = function () {
 };
 
 azdataQueryPlan.prototype.highlightExpensiveOperator = function (costPredicate) {
-    const HIGHLIGHTER_COLOR = '#cd2026'; // Accessiblity - color red
+    const HIGHLIGHTER_COLOR = '#CD2026'; // Accessiblity - color red
     const STROKE_WIDTH = 1;
 
     const expensiveNode = this.findExpensiveOperator(costPredicate);

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -1266,7 +1266,7 @@ azdataQueryPlan.prototype.redrawExpensiveOperatorHighlighting = function () {
 };
 
 azdataQueryPlan.prototype.highlightExpensiveOperator = function (costPredicate) {
-    const HIGHLIGHTER_COLOR = '#CD2026'; // Accessiblity - color red
+    const HIGHLIGHTER_COLOR = '#CD2026'; // Accessible Red
     const STROKE_WIDTH = 1;
 
     const expensiveNode = this.findExpensiveOperator(costPredicate);

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -655,7 +655,7 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
         cellStyle[mxConstants.STYLE_STROKECOLOR] = 'transparent';
         cellStyle[mxConstants.STYLE_CELL_HIGHLIGHT_DASHED] = false;
         cellStyle[mxConstants.STYLE_CELL_HIGHLIGHT_STROKE_WIDTH] = '3';
-        cellStyle[mxConstants.STYLE_CELL_HIGHLIGHT_COLOR] = '#00ff00';
+        cellStyle[mxConstants.STYLE_CELL_HIGHLIGHT_COLOR] = '#4AA564';
 
         graph.getStylesheet().putDefaultVertexStyle(cellStyle);
 

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -1266,7 +1266,7 @@ azdataQueryPlan.prototype.redrawExpensiveOperatorHighlighting = function () {
 };
 
 azdataQueryPlan.prototype.highlightExpensiveOperator = function (costPredicate) {
-    const HIGHLIGHTER_COLOR = '#FFA500'; // Orange
+    const HIGHLIGHTER_COLOR = '#cd2026'; // Accessiblity - color red
     const STROKE_WIDTH = 1;
 
     const expensiveNode = this.findExpensiveOperator(costPredicate);


### PR DESCRIPTION
Adjusts the outline color that is used to highlight expensive operators in query execution plans. Below is a more accessible red color, instead of the previous orange color being used.
![image](https://user-images.githubusercontent.com/87730006/195457299-7fc0bde5-27c2-4d95-a248-fd893ee8bc50.png)

The selection color has also been updated as part of this PR:
![image](https://user-images.githubusercontent.com/87730006/195460258-bfbf3439-14b8-4ce2-abd9-ddd1bf73a370.png)