### PR TITLE
Include nodes with 0 cost value for highlight eligibility

### DIFF
--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -1390,7 +1390,7 @@ azdataQueryPlan.prototype.findExpensiveOperator = function (getExpenseMetricValu
         const node = stack.pop();
         const costValue = getExpenseMetricValue(node);
 
-        if (costValue && costValue >= 0) {
+        if (costValue !== undefined && costValue >= 0) {
             expensiveOperators.push(node);
             expensiveCostValues.push(costValue);
         }

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -1390,7 +1390,7 @@ azdataQueryPlan.prototype.findExpensiveOperator = function (getExpenseMetricValu
         const node = stack.pop();
         const costValue = getExpenseMetricValue(node);
 
-        if (costValue) {
+        if (costValue && costValue >= 0) {
             expensiveOperators.push(node);
             expensiveCostValues.push(costValue);
         }


### PR DESCRIPTION
Corrects logic to include nodes with 0 a zero cost value. A zero value is falsy, and that was preventing nodes with a cost value of 0 to be overlooked by the highlighting logic.