### PR TITLE
Returns the node ID of the highlighted node found in a plan to center.

### DIFF
--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -1365,14 +1365,14 @@ azdataQueryPlan.prototype.highlightExpensiveOperator = function (getExpenseMetri
 
     const expensiveNode = this.findExpensiveOperator(getExpenseMetricValue);
     if (!expensiveNode) {
-        return false;
+        return undefined;
     }
 
     this.expensiveCell = this.graph.model.getCell(expensiveNode.id);
     this.expensiveCellHighlighter = new mxCellHighlight(this.graph, HIGHLIGHTER_COLOR, STROKE_WIDTH);
     this.expensiveCellHighlighter.highlight(this.graph.view.getState(this.expensiveCell));
 
-    return true;
+    return expensiveNode.id;
 };
 
 /**


### PR DESCRIPTION
This PR is to address this issue found in the Azure Data Studio repo: https://github.com/microsoft/azuredatastudio/issues/20869

The issue revolves around centering the expensive node found, so that the user doesn't need to pan around to locate themselves.