### PR TITLE
Removing space key from showing up tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azdataGraph",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azdataGraph",
-      "version": "0.0.57",
+      "version": "0.0.58",
       "license": "Apache-2.0",
       "devDependencies": {
         "grunt": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azdataGraph",
   "description": "azdataGraph is a derivative of mxGraph, which is a fully client side JavaScript diagramming library that uses SVG and HTML for rendering.",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "homepage": "https://github.com/microsoft/azdataGraph",
   "author": "Microsoft",
   "license": "Apache-2.0",

--- a/src/js/azdata/azdataQueryPlan.js
+++ b/src/js/azdata/azdataQueryPlan.js
@@ -459,7 +459,7 @@ azdataQueryPlan.prototype.init = function (queryPlanConfiguration) {
 
             mxEvent.addListener(cellBodyContainer, 'keydown', (evt) => {
                 if (this.showTooltipOnClick && this.showTooltip) {
-                    if (evt.keyCode === 13 || evt.keyCode === 32) {
+                    if (evt.keyCode === 13) {
                         if (this.tooltipHandler.isVisible) {
                             this.tooltipHandler.hide();
                         } else {


### PR DESCRIPTION
This will fix [#20777](https://github.com/microsoft/azuredatastudio/issues/20777).

Previously space key was showing tooltip which prevented the users from entering scan mode. This PR fixes that. 