### PR TITLE
Fixing graph visibility issues in the new graph component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azdataGraph",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azdataGraph",
-      "version": "0.0.58",
+      "version": "0.0.59",
       "license": "Apache-2.0",
       "devDependencies": {
         "grunt": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azdataGraph",
   "description": "azdataGraph is a derivative of mxGraph, which is a fully client side JavaScript diagramming library that uses SVG and HTML for rendering.",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "homepage": "https://github.com/microsoft/azdataGraph",
   "author": "Microsoft",
   "license": "Apache-2.0",

--- a/src/js/shape/mxShape.js
+++ b/src/js/shape/mxShape.js
@@ -383,7 +383,7 @@ mxShape.prototype.redraw = function()
 	if (this.visible && this.checkBounds())
 	{	
 		if(this.node?.style){
-			this.node.style.visibility = 'visible';
+			this.node.style.display = '';
 		}
 
 		this.clear();
@@ -401,7 +401,7 @@ mxShape.prototype.redraw = function()
 	}
 	else
 	{
-		this.node.style.visibility = 'hidden';
+		this.node.style.display = 'none';
 		this.boundingBox = null;
 	}
 };

--- a/test/queryplan/queryplanParentVisibility.html
+++ b/test/queryplan/queryplanParentVisibility.html
@@ -1,0 +1,60 @@
+<!--
+ Tests the visibility of graph contents when the parent container is hidden. In default case, the graph contents are visible even when the parent container is hidden. However, I have made changes to mxShape class to use display: none instead of visibility: hidden. This change makes the graph contents invisible when the parent container is hidden.
+-->
+<html>
+
+<head>
+	<title>Query Plan test</title>
+	<script type="text/javascript">
+		mxForceIncludes = true;
+		mxBasePath = '../../src';
+	</script>
+	<script type="text/javascript" src="./src/js/graph.js"></script>
+	<script type="text/javascript" src="../../src/js/mxClient.js"></script>
+	<script type="text/javascript" src="./src/js/queryPlanSetup.js"></script>
+	<script type="text/javascript">
+
+		function main(container) {
+			var graph = getGraph();
+
+			var imageBasePath = './icons/';
+			var iconPaths = getIconPaths(imageBasePath);
+			var badgePaths = getBadgePaths(imageBasePath);
+			var collapseExpandPaths = getCollapseExpandPaths(imageBasePath);
+
+			let queryPlanConfiguration = {
+				container: container,
+				queryPlanGraph: graph,
+				iconPaths: iconPaths,
+				badgeIconPaths: badgePaths,
+				expandCollapsePaths: collapseExpandPaths,
+				showTooltipOnClick: true
+			};
+			new azdataQueryPlan(queryPlanConfiguration);
+		};
+
+		setInterval(function () {
+			const container = document.getElementById('graphContainer');
+			container.style.visibility = container.style.visibility === 'hidden' ? '' : 'hidden';
+		}, 5000);
+
+	</script>
+	<style>
+		#graphContainer {
+			position: relative;
+			overflow: scroll;
+			width: 1500px;
+			height: 800px;
+			cursor: default;
+			border: 1px solid;
+			margin-top: 100px;
+			margin-left: 100px;
+		}
+	</style>
+</head>
+
+<body onload="main(document.getElementById('graphContainer'))">
+	<div id="graphContainer"></div>
+</body>
+
+</html>


### PR DESCRIPTION
Presently, mxgraph uses the visibility attribute to manage the visibility of its items. However, an issue arises with this approach: the child nodes remain visible even when their parent nodes are hidden. This poses a problem for us because when we attempt to conceal the parent container of the graph, the edges and selection boxes continue to be displayed.

The PR fixes it by switching to 'display' from 'visibility' attribute in css. It ensures that even when a tab containing mxgraph is opened and subsequently switched to another tab, the edges are no longer visible.

Example of the bug.
![image](https://github.com/microsoft/azdataGraph/assets/6816294/b9fc7836-4287-4a8c-b6d6-3c892b36843c)
![image](https://github.com/microsoft/azdataGraph/assets/6816294/91ed9cd4-660f-443a-a6ac-f9fcd3814da8)
