### PR TITLE
Fixing inverted expand collapse icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azdataGraph",
   "description": "azdataGraph is a derivative of mxGraph, which is a fully client side JavaScript diagramming library that uses SVG and HTML for rendering.",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "homepage": "https://github.com/microsoft/azdataGraph",
   "author": "Microsoft",
   "license": "Apache-2.0",

--- a/src/css/common.css
+++ b/src/css/common.css
@@ -228,11 +228,11 @@ td.mxPopupMenuIcon {
 }
 
 .graph-cell .graph-icon-badge-expand.expanded {
-	background-image: url('../images/expanded.gif');
+	background-image: url('../images/collapsed.gif');
 }
 
 .graph-cell .graph-icon-badge-expand.collapsed {
-	background-image: url('../images/collapsed.gif');
+	background-image: url('../images/expanded.gif');
 }
 
 .graph-cell-cost{


### PR DESCRIPTION
Previously, I was showing expand icon for expanded nodes. This PR fixes that. 

Now:
![image](https://github.com/user-attachments/assets/d4e148a8-7fda-4991-9774-f802add4af66)

Previously: 
![image](https://github.com/user-attachments/assets/df6db896-1b43-4fa5-98db-ef1d671e78ca)

